### PR TITLE
Clarify deploy instructions for serving static assets.

### DIFF
--- a/_site/docs/index.html
+++ b/_site/docs/index.html
@@ -653,7 +653,9 @@ class AppSpec extends FlatSpecHelper {
 <p class="lead">The <code>pom.xml</code> of generated Finatra projects builds a single,
 deployable "fatjar" with:</p>
 <pre class="prettyprint">mvn package</pre>
-<p class="lead">This produces a runnable jar  with scala, finatra, and any other dependent libraries included inside the <code>target/</code> directory.</p>
+<p class="lead">This produces a runnable jar  with scala, finatra, and any other dependent libraries included inside the <code>target/</code> directory.  Then you can run the jar via:</p>
+<pre class="prettyprint">java -jar target/finatra_app.jar -com.twitter.finatra.config.env='production'</pre>
+<p class="lead">to serve both generated html and assets in <code>src/main/resources/public</code>.</p>
 <p class="lead">If you are using Heroku, the included <code><a href="https://github.com/twitter/finatra/blob/master/script/finatra/share/Procfile">Procfile</a></code> will work out of the box.
 </section>
 


### PR DESCRIPTION
It took a while to debug why the static assets weren't being served while running the fatjar.  This update to the docs should point a new user that setting the `-com.twitter.finatra.config.env='production'` flag will allow the static assets to be served from the fatjar.

Feel free to rephrase in any way you see fit!  :)
